### PR TITLE
[IMP] Add image size's twig filters

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -60,6 +60,18 @@ class Plugin extends PluginBase
                 'resize' => function($file_path, $width = false, $height = false, $options = []) {
                     $image = new Image($file_path);
                     return $image->resize($width, $height, $options);
+                },
+                'imageWidth' => function($image) {
+                    if (!$image instanceOf Image) {
+                        $image = new Image($image);
+                    }
+                    return getimagesize($image->getCachedImagePath())[0];
+                },
+                'imageHeight' => function($image) {
+                    if (!$image instanceOf Image) {
+                        $image = new Image($image);
+                    }
+                    return getimagesize($image->getCachedImagePath())[1];
                 }
             ]
         ];


### PR DESCRIPTION
Useful if you need to know the size of an image resized only by one side.

ex: `{{ '/path/to/image.jpg' | resize(250) }}` give you a filename like `thumb__250_0_0_0_auto.jpg` that does not contain computed heigth.