### PR TITLE
decode file path string

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -58,7 +58,7 @@ class Plugin extends PluginBase
         return [
             'filters' => [
                 'resize' => function($file_path, $width = false, $height = false, $options = []) {
-                    $image = new Image($file_path);
+                    $image = new Image(rawurldecode($file_path));
                     return $image->resize($width, $height, $options);
                 }
             ]


### PR DESCRIPTION
This fixes some issues. For example `function is_file ($filename) {}` return false for images with space(%20) even if the image exists   https://github.com/toughdeveloper/oc-imageresizer-plugin/blob/f3c6ef89ab967876a0b87cb0bd57194c941bfc8a/classes/Image.php#L68
