### PR TITLE
set the composer type to october-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "toughdeveloper/imageresizer",
+    "type": "october-plugin",
     "description": "October CMS Plugin to resize and compress images.",
     "license": "MIT",
     "website": "https://octobercms.com/plugin/toughdeveloper-imageresizer",


### PR DESCRIPTION
In order to correctly include this plugin in an october project through composer, the type needs to be set in composer.json