### PR TITLE
Fix composer support for pulling into projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,11 @@
 {
     "name": "toughdeveloper/imageresizer",
+    "type": "october-plugin",
     "description": "October CMS Plugin to resize and compress images.",
     "license": "MIT",
     "website": "https://octobercms.com/plugin/toughdeveloper-imageresizer",
     "require": {
+        "composer/installers": "~1.0",
         "tinify/tinify": "^1.3"
     }
 }


### PR DESCRIPTION
Right now adding this plugin as a requirement to a composer file will result in it being added to /vendor instead of /plugins. This fixes that.