### PR TITLE
Allows to use remote images

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -361,5 +361,4 @@ class Image
     {
         return $this->getCachedImagePath(true);
     }
-
 }

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -385,6 +385,11 @@ class Image
         $tempImage = $this->generateStoragePath($filePath);
         $tempFullPath = storage_path('app/' . $tempImage);
 
+        // Check if remote image was already downloaded
+        if (Storage::exists($tempImage)) {
+            return $tempFullPath;
+        }
+
         Http::get($filePath, function ($http) use ($tempFullPath) {
             $http->toFile($tempFullPath);
         });

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -4,12 +4,11 @@ use ToughDeveloper\ImageResizer\Models\Settings;
 use October\Rain\Database\Attach\File;
 use Tinify\Tinify;
 use Tinify\Source;
-use File as FileHelper;
-use October\Rain\Network\Http;
-use Illuminate\Support\Facades\Storage;
 
 class Image
 {
+    use RemoteImageTrait;
+
     /**
      * Original path of image
      */
@@ -363,102 +362,4 @@ class Image
         return $this->getCachedImagePath(true);
     }
 
-    /**
-     * Determine if a file path is a remote image
-     *
-     * @param string $filePath
-     * @return boolean
-     */
-    protected function isRemoteFile($filePath)
-    {
-        return filter_var($filePath, FILTER_VALIDATE_URL);
-    }
-
-    /**
-     * Store a remote image locally
-     *
-     * @param string $filePath
-     * @return string
-     */
-    protected function getRemoteFile($filePath)
-    {
-        $tempImage = $this->generateStoragePath($filePath);
-        $tempFullPath = storage_path('app/' . $tempImage);
-
-        // Check if remote image was already downloaded
-        if (Storage::exists($tempImage)) {
-            return $tempFullPath;
-        }
-
-        // If URL doesn't have extension, check if exists a file with one of the allowed extensions
-        $imageExists = $this->checkLocalRemoteImage($tempImage);
-
-        // If found, use already downloaded image
-        if ($imageExists) {
-            return storage_path('app/' . $imageExists);
-        }
-
-        // Download image from remote location
-        Http::get($filePath, function ($http) use ($tempFullPath) {
-            $http->toFile($tempFullPath);
-        });
-
-        // If URL doesn't have extension, discover extension and rename local image
-        if (!FileHelper::extension($tempFullPath)) {
-            $extension = $this->discoverImageExtension($tempFullPath);
-            $newFullPath = sprintf('%s%s', $tempFullPath, $extension);
-            rename($tempFullPath, $newFullPath);
-            $tempFullPath = $newFullPath;
-        }
-
-        return $tempFullPath;
-    }
-
-    /**
-     * Generate storage path to store cached remote images
-     *
-     * @param string $filePath
-     * @return string
-     */
-    protected function generateStoragePath($filePath)
-    {
-        $extension = FileHelper::extension($filePath);
-        $tempPath = $this->file->getStorageDirectory() . $this->getPartitionDirectory();
-        $tempFilename = md5($filePath);
-
-        Storage::makeDirectory($tempPath);
-
-        $fileMask = $extension ? '%s%s.%s' : '%s%s';
-
-        return sprintf($fileMask, $tempPath, $tempFilename, $extension);
-    }
-
-    /**
-     * If remote image doesn't expose file extension, discover by looking downloaded file
-     *
-     * @param string $filePath
-     * @return string
-     */
-    protected function discoverImageExtension($filePath)
-    {
-        $imageType = exif_imagetype($filePath);
-        $extension = image_type_to_extension($imageType);
-        return $extension;
-    }
-
-    /**
-     * If URL doesn't have extension, check if exists a file with one of the allowed extensions
-     *
-     * @param $string $filePath
-     * @return Collection
-     */
-    protected function checkLocalRemoteImage($filePath)
-    {
-        $allowedExtensions = File::$imageExtensions;
-
-        return collect($allowedExtensions)->map(function ($imageType) use ($filePath) {
-            $findImage = sprintf('%s.%s', $filePath, $imageType);
-            return Storage::exists($findImage) ? $findImage : false;
-        })->filter()->first();
-    }
 }

--- a/classes/RemoteImageTrait.php
+++ b/classes/RemoteImageTrait.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace ToughDeveloper\ImageResizer\Classes;
+
+use File as FileHelper;
+use October\Rain\Network\Http;
+use October\Rain\Database\Attach\File;
+use Illuminate\Support\Facades\Storage;
+
+trait RemoteImageTrait
+{
+    /**
+     * Determine if a file path is a remote image
+     *
+     * @param string $filePath
+     * @return boolean
+     */
+    protected function isRemoteFile($filePath)
+    {
+        return filter_var($filePath, FILTER_VALIDATE_URL);
+    }
+
+    /**
+     * Store a remote image locally
+     *
+     * @param string $filePath
+     * @return string
+     */
+    protected function getRemoteFile($filePath)
+    {
+        $tempImage = $this->generateStoragePath($filePath);
+        $tempFullPath = storage_path('app/' . $tempImage);
+
+        // Check if remote image was already downloaded
+        if (Storage::exists($tempImage)) {
+            return $tempFullPath;
+        }
+
+        // If URL doesn't have extension, check if exists a file with one of the allowed extensions
+        $imageExists = $this->checkLocalRemoteImage($tempImage);
+
+        // If found, use already downloaded image
+        if ($imageExists) {
+            return storage_path('app/' . $imageExists);
+        }
+
+        // Download image from remote location
+        Http::get($filePath, function ($http) use ($tempFullPath) {
+            $http->toFile($tempFullPath);
+        });
+
+        // If URL doesn't have extension, discover extension and rename local image
+        if (!FileHelper::extension($tempFullPath)) {
+            $extension = $this->discoverImageExtension($tempFullPath);
+            $newFullPath = sprintf('%s%s', $tempFullPath, $extension);
+            rename($tempFullPath, $newFullPath);
+            $tempFullPath = $newFullPath;
+        }
+
+        return $tempFullPath;
+    }
+
+    /**
+     * Generate storage path to store cached remote images
+     *
+     * @param string $filePath
+     * @return string
+     */
+    protected function generateStoragePath($filePath)
+    {
+        $extension = FileHelper::extension($filePath);
+        $tempPath = $this->file->getStorageDirectory() . $this->getPartitionDirectory();
+        $tempFilename = md5($filePath);
+
+        Storage::makeDirectory($tempPath);
+
+        $fileMask = $extension ? '%s%s.%s' : '%s%s';
+
+        return sprintf($fileMask, $tempPath, $tempFilename, $extension);
+    }
+
+    /**
+     * If remote image doesn't expose file extension, discover by looking downloaded file
+     *
+     * @param string $filePath
+     * @return string
+     */
+    protected function discoverImageExtension($filePath)
+    {
+        $imageType = exif_imagetype($filePath);
+        $extension = image_type_to_extension($imageType);
+        return $extension;
+    }
+
+    /**
+     * If URL doesn't have extension, check if exists a file with one of the allowed extensions
+     *
+     * @param $string $filePath
+     * @return Collection
+     */
+    protected function checkLocalRemoteImage($filePath)
+    {
+        $allowedExtensions = File::$imageExtensions;
+
+        return collect($allowedExtensions)->map(function ($imageType) use ($filePath) {
+            $findImage = sprintf('%s.%s', $filePath, $imageType);
+            return Storage::exists($findImage) ? $findImage : false;
+        })->filter()->first();
+    }
+}

--- a/classes/RemoteImageTrait.php
+++ b/classes/RemoteImageTrait.php
@@ -68,7 +68,7 @@ trait RemoteImageTrait
      */
     protected function generateStoragePath($filePath)
     {
-        $extension = FileHelper::extension($filePath);
+        $extension = $this->getRemoteFileExtension($filePath);
         $tempPath = $this->file->getStorageDirectory() . $this->getPartitionDirectory();
         $tempFilename = md5($filePath);
 
@@ -77,6 +77,22 @@ trait RemoteImageTrait
         $fileMask = $extension ? '%s%s.%s' : '%s%s';
 
         return sprintf($fileMask, $tempPath, $tempFilename, $extension);
+    }
+
+    /**
+     * Get file extension from remote image URL
+     *
+     * @param string $filePath
+     * @return string
+     */
+    protected function getRemoteFileExtension($filePath)
+    {
+        // Remove query string from url
+        if (parse_url($filePath, PHP_URL_QUERY)) {
+            $filePath = strtok($filePath, '?');
+        }
+
+        return FileHelper::extension($filePath);
     }
 
     /**


### PR DESCRIPTION
This PR allows to use remote images.

**Note:** there are 2 scenarios, depending if the url exposes the image extension or not

**How it works:**
When the class is initialized, we check if file path is a url.

In that case, we download the remote image to the storage folder (will be saved using the md5 of the url as filename).

After saving, we continue the normal resize/compression process using the local path.

If the URL doesn't expose the file extension, we try to discover by looking file mime type of downloaded file.

Because the plugin doesn't accept images without extension, we need to add the extension to the downloaded image (move from `<image>` to `<image>.<extension>`)

Next time image is requested, already downloaded file will be served.

**How to use:**

```
<img src="{{ 'https://images.unsplash.com/photo-1549880338-65ddcdfd017b'|resize(100) }}" />
<img src="{{ 'https://via.placeholder.com/300.png'|resize(100) }}" />
<img src="{{ 'https://images.unsplash.com/photo-1549880338-65ddcdfd017b?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80'|resize(100) }}" />
```